### PR TITLE
safely unwrap the properties field

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1579,10 +1579,9 @@ impl Arweave {
         let _ = metadata.insert("image".to_string(), Value::String(image_link));
 
         let properties = match metadata["properties"].as_object_mut()  {
-            Some(properties) => properties,
+            Some(p) => p,
             None => {
-                let properties = json!({});
-                let _ = metadata.insert("properties".to_string(), properties);
+                let _ = metadata.insert("properties".to_string(), json!({}));
                 metadata["properties"].as_object_mut().unwrap()
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1578,7 +1578,14 @@ impl Arweave {
         let metadata = metadata.as_object_mut().unwrap();
         let _ = metadata.insert("image".to_string(), Value::String(image_link));
 
-        let properties = metadata["properties"].as_object_mut().unwrap();
+        let properties = match metadata["properties"].as_object_mut()  {
+            Some(properties) => properties,
+            None => {
+                let properties = json!({});
+                let _ = metadata.insert("properties".to_string(), properties);
+                metadata["properties"].as_object_mut().unwrap()
+            }
+        };
         let _ = properties.insert("files".to_string(), Value::Array(files_array));
         // let _ = metadata.insert("properties".to_string(), Value::Object(properties.clone()));
 


### PR DESCRIPTION
"properties" field is not mandatory in `EPI-1155`